### PR TITLE
refactor(forex): unificar what_to_show en rutas diarias y de filtro

### DIFF
--- a/agent_core/data_manager.py
+++ b/agent_core/data_manager.py
@@ -184,10 +184,11 @@ class DataManager:
             logger.error(f"Error cargando o procesando caché {filename}: {e}", exc_info=True)
             return None 
 
-    def get_levels_data(self, target_date: datetime.date, symbol: str, sec_type: str, exchange: str, currency: str, 
-                        timeframe_daily='1 day', timeframe_intra='5 mins', 
-                        premarket_start_hour=4, market_open_hour=9, market_open_minute=30, 
-                        use_cache=True, **contract_kwargs):
+    def get_levels_data(self, target_date: datetime.date, symbol: str, sec_type: str, exchange: str, currency: str,
+                        timeframe_daily='1 day', timeframe_intra='5 mins',
+                        premarket_start_hour=4, market_open_hour=9, market_open_minute=30,
+                        use_cache=True, what_to_show: str = config.WHAT_TO_SHOW,
+                        **contract_kwargs):
         df_previous_day = pd.DataFrame()
         df_premarket = pd.DataFrame()
         
@@ -201,7 +202,7 @@ class DataManager:
             contract_obj = self._resolve_contract(symbol, sec_type, exchange, currency, **contract_kwargs)
             end_dt_prev_day_market = self.MARKET_TZ.localize(datetime.datetime.combine(prev_business_day, datetime.time(23, 59, 59)))
             end_dt_prev_day_utc_str = end_dt_prev_day_market.astimezone(self.UTC_TZ).strftime('%Y%m%d %H:%M:%S %Z')
-            df_fetched_pd = self._fetch_data_core(contract_obj, end_dt_prev_day_utc_str, '1 D', timeframe_daily, True, 'TRADES')
+            df_fetched_pd = self._fetch_data_core(contract_obj, end_dt_prev_day_utc_str, '1 D', timeframe_daily, True, what_to_show)
             if df_fetched_pd is not None and not df_fetched_pd.empty:
                 start_utc = self.MARKET_TZ.localize(datetime.datetime.combine(prev_business_day, datetime.time.min)).astimezone(self.UTC_TZ)
                 end_utc = self.MARKET_TZ.localize(datetime.datetime.combine(prev_business_day, datetime.time.max)).astimezone(self.UTC_TZ)
@@ -221,7 +222,7 @@ class DataManager:
             duration_str_pm = f"{max(120, duration_seconds_pm + 120)} S"
             
             contract_obj = self._resolve_contract(symbol, sec_type, exchange, currency, **contract_kwargs)
-            df_fetched_pm = self._fetch_data_core(contract_obj, end_dt_pm_utc_req_str, duration_str_pm, timeframe_intra, False, 'TRADES')
+            df_fetched_pm = self._fetch_data_core(contract_obj, end_dt_pm_utc_req_str, duration_str_pm, timeframe_intra, False, what_to_show)
             if df_fetched_pm is not None and not df_fetched_pm.empty:
                 start_utc = start_dt_pm_market.astimezone(self.UTC_TZ)
                 end_utc = end_dt_pm_market.astimezone(self.UTC_TZ)

--- a/config.py
+++ b/config.py
@@ -38,7 +38,7 @@ EMA_FILTER_TIMEFRAMES = [
 # --- FIN DE LA MODIFICACIÓN ---
 DEFAULT_DATA_DURATION = '5 D'
 USE_RTH = False
-WHAT_TO_SHOW = 'TRADES'
+WHAT_TO_SHOW = 'MIDPOINT'
 
 # --- Configuración de Niveles y Estrategia ---
 LEVEL_RANGES = {

--- a/ui/app.py
+++ b/ui/app.py
@@ -111,10 +111,11 @@ def run_single_backtest_iteration(df_enriched, tz_handler, ema_filter_mode):
     for date in unique_dates:
         date_obj = date.date()
         df_prev, df_pm = dm.get_levels_data(
-            target_date=date_obj, symbol=st.session_state.ui_symbol, 
-            sec_type=st.session_state.ui_sec_type, exchange=st.session_state.ui_exchange, 
-            currency=st.session_state.ui_currency, use_cache=st.session_state.ui_use_cache, 
-            primary_exchange=st.session_state.ui_primary_exchange
+            target_date=date_obj, symbol=st.session_state.ui_symbol,
+            sec_type=st.session_state.ui_sec_type, exchange=st.session_state.ui_exchange,
+            currency=st.session_state.ui_currency, use_cache=st.session_state.ui_use_cache,
+            primary_exchange=st.session_state.ui_primary_exchange,
+            what_to_show=st.session_state.ui_what_to_show
         )
         levels = {**dm.calculate_pdh_pdl(df_prev), **dm.calculate_pmh_pml(df_pm)}
         df_day = df_enriched[df_enriched.index.date == date_obj]
@@ -316,10 +317,11 @@ def process_and_prepare_daily_data_visual():
             return
         try:
             df_prev, df_pm = dm.get_levels_data(
-                target_date=date_to_replay, symbol=st.session_state.ui_symbol, 
-                sec_type=st.session_state.ui_sec_type, exchange=st.session_state.ui_exchange, 
-                currency=st.session_state.ui_currency, use_cache=st.session_state.ui_use_cache, 
-                primary_exchange=st.session_state.ui_primary_exchange
+                target_date=date_to_replay, symbol=st.session_state.ui_symbol,
+                sec_type=st.session_state.ui_sec_type, exchange=st.session_state.ui_exchange,
+                currency=st.session_state.ui_currency, use_cache=st.session_state.ui_use_cache,
+                primary_exchange=st.session_state.ui_primary_exchange,
+                what_to_show=st.session_state.ui_what_to_show
             )
             st.session_state.static_levels = {**dm.calculate_pdh_pdl(df_prev), **dm.calculate_pmh_pml(df_pm)}
         finally:


### PR DESCRIPTION
## Summary
- remove hardcoded TRADES in daily level and premarket fetches
- default MIDPOINT for data normalization via config
- propagate what_to_show through level retrieval paths

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bc9a9632bc8324926b36a57dcd4e4b