### PR TITLE
refactor(forex): unificar what_to_show en rutas diarias y de filtro

### DIFF
--- a/agent_core/data_manager.py
+++ b/agent_core/data_manager.py
@@ -204,8 +204,10 @@ class DataManager:
             sec_type = "FOREX"
             exchange = "IDEALPRO"
 
-        rth_prev_day, what_to_show = self._normalize_fetch_params(market, True, "TRADES")
-        rth_premarket, what_to_show = self._normalize_fetch_params(market, False, what_to_show)
+        rth_prev_day, what_to_show = self._normalize_fetch_params(
+            market, True, self.config.WHAT_TO_SHOW
+        )
+        rth_premarket, _ = self._normalize_fetch_params(market, False, what_to_show)
 
         prev_business_day = (pd.Timestamp(target_date) - pd.tseries.offsets.BDay(1)).date()
         prev_day_str = prev_business_day.strftime('%Y%m%d')

--- a/ui/app.py
+++ b/ui/app.py
@@ -476,7 +476,6 @@ def handle_market_change():
             config.STOCKS_PRIMARY_EXCHANGES[0] if config.STOCKS_PRIMARY_EXCHANGES else ""
         )
         st.session_state.ui_sec_type = config.DEFAULT_SEC_TYPE
-    st.session_state.ui_what_to_show = "TRADES"
 
     exec_options = get_exec_timeframe_options(market)
     if st.session_state.ui_exec_timeframe not in exec_options:
@@ -529,7 +528,9 @@ with st.sidebar:
         st.date_input("Inicio Descarga", key="ui_download_start")
         st.date_input("Fin Descarga", key="ui_download_end")
         st.toggle("Usar solo RTH", key="ui_use_rth")
-        st.session_state.ui_what_to_show = st.session_state.get("ui_what_to_show", "TRADES")
+        st.session_state.ui_what_to_show = st.session_state.get(
+            "ui_what_to_show", config.WHAT_TO_SHOW
+        )
         st.selectbox(
             "Fuente de Datos Velas",
             options=['TRADES', 'MIDPOINT', 'BID', 'ASK'],


### PR DESCRIPTION
## Summary
- Normaliza what_to_show usando `config.WHAT_TO_SHOW` en descargas de niveles y evita reasignaciones posteriores
- Mantiene el selector `what_to_show` sin reinicios al cambiar de mercado y usa el valor global por defecto

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68bc9cb1f4408324a56c82523ea322c2