### PR TITLE
Add drawdown curve visualization and metrics

### DIFF
--- a/agent_core/metrics.py
+++ b/agent_core/metrics.py
@@ -4,6 +4,8 @@ import numpy as np
 import logging
 from decimal import Decimal
 
+from agent_core.performance import drawdown_curve_from_equity
+
 # Logger específico
 logger = logging.getLogger(__name__)
 
@@ -82,7 +84,8 @@ def calculate_performance_metrics(trades: list, initial_capital: float,
         try:
             equity_df = pd.DataFrame(equity_history, columns=["time", "equity"])
             equity_df["equity"] = pd.to_numeric(equity_df["equity"])
-            metrics["Max Drawdown (%)"] = compute_max_drawdown(equity_df["equity"])
+            dd = drawdown_curve_from_equity(equity_df["equity"])
+            metrics["Max Drawdown (%)"] = dd.attrs.get('max_dd_pct', float(dd['dd_pct'].min()))
         except Exception as e_dd:
             logger.error(f"Error calculando Max Drawdown: {e_dd}", exc_info=True)
             metrics["Max Drawdown (%)"] = 0.0  # Fallback a 0.0 en caso de error
@@ -94,4 +97,5 @@ if __name__ == "__main__":
     # Pequeña prueba manual del cálculo de Max Drawdown
     equity_example = pd.Series([100, 120, 80, 90, 70, 150])
     print("Equity:", equity_example.tolist())
-    print("Max Drawdown (%):", compute_max_drawdown(equity_example))
+    dd_example = drawdown_curve_from_equity(equity_example)
+    print("Max Drawdown (%):", dd_example.attrs.get('max_dd_pct'))

--- a/agent_core/performance.py
+++ b/agent_core/performance.py
@@ -1,0 +1,18 @@
+import numpy as np
+import pandas as pd
+
+
+def drawdown_curve_from_equity(equity: pd.Series) -> pd.DataFrame:
+    """
+    Recibe Serie de equity ($) indexada por datetime.
+    Devuelve DataFrame con:
+      - equity
+      - rolling_peak (máximo acumulado)
+      - dd_pct (drawdown %, negativo), y en attrs['max_dd_pct'] el mínimo (%).
+    """
+    eq = equity.astype(float).copy()
+    rolling_peak = eq.cummax()
+    dd_pct = (eq / rolling_peak - 1.0) * 100.0
+    df = pd.DataFrame({'equity': eq, 'rolling_peak': rolling_peak, 'dd_pct': dd_pct})
+    df.attrs['max_dd_pct'] = float(dd_pct.min()) if len(dd_pct) else 0.0
+    return df


### PR DESCRIPTION
## Summary
- add utility to compute drawdown curve from equity
- plot drawdown curve in results and comparison dashboards
- derive max drawdown metrics from drawdown curve

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bdc9bbc078832485e5ddc9ae132056