### PR TITLE
refactor: centralize drawdown calculations

### DIFF
--- a/agent_core/performance.py
+++ b/agent_core/performance.py
@@ -1,18 +1,42 @@
-import numpy as np
 import pandas as pd
 
 
-def drawdown_curve_from_equity(equity: pd.Series) -> pd.DataFrame:
+def drawdown_curve_pct(equity: pd.Series) -> pd.DataFrame:
+    """Return drawdown curve (%) from a dollar-denominated equity series.
+
+    Parameters
+    ----------
+    equity : pd.Series
+        Equity curve in dollars indexed by datetime.
+
+    Returns
+    -------
+    pd.DataFrame
+        DataFrame with columns:
+        - ``equity``: original equity values.
+        - ``rolling_peak``: running peak of the equity curve.
+        - ``dd_pct``: drawdown percentage (negative values).
     """
-    Recibe Serie de equity ($) indexada por datetime.
-    Devuelve DataFrame con:
-      - equity
-      - rolling_peak (máximo acumulado)
-      - dd_pct (drawdown %, negativo), y en attrs['max_dd_pct'] el mínimo (%).
-    """
+
     eq = equity.astype(float).copy()
     rolling_peak = eq.cummax()
     dd_pct = (eq / rolling_peak - 1.0) * 100.0
-    df = pd.DataFrame({'equity': eq, 'rolling_peak': rolling_peak, 'dd_pct': dd_pct})
-    df.attrs['max_dd_pct'] = float(dd_pct.min()) if len(dd_pct) else 0.0
+    return pd.DataFrame({"equity": eq, "rolling_peak": rolling_peak, "dd_pct": dd_pct})
+
+
+def max_drawdown_pct(equity: pd.Series) -> float:
+    """Compute the maximum drawdown percentage (as a positive value)."""
+
+    if equity is None or len(equity) == 0:
+        return 0.0
+
+    dd_curve = drawdown_curve_pct(equity)
+    return float(abs(dd_curve["dd_pct"].min())) if len(dd_curve) else 0.0
+
+
+def drawdown_curve_from_equity(equity: pd.Series) -> pd.DataFrame:
+    """Backward compatible helper that also stores max drawdown in ``attrs``."""
+
+    df = drawdown_curve_pct(equity)
+    df.attrs["max_dd_pct"] = -float(abs(df["dd_pct"].min())) if len(df) else 0.0
     return df

--- a/ui/results_renderer.py
+++ b/ui/results_renderer.py
@@ -11,7 +11,7 @@ import plotly.graph_objects as go
 import plotly.express as px
 
 from agent_core.metrics import calculate_performance_metrics
-from agent_core.performance import drawdown_curve_from_equity
+from agent_core.performance import drawdown_curve_pct, max_drawdown_pct
 
 def generate_calendar_html(pnl_by_day, year, month, monthly_pnl, monthly_start_equity):
     """Genera el HTML para el calendario de rendimiento mensual."""
@@ -258,13 +258,13 @@ def render_global_results(filter_name: str = ""):
                 key=f"{filter_name}_equity",
             )
 
-            dd_df = drawdown_curve_from_equity(equity_df_chart['equity'])
+            dd_df = drawdown_curve_pct(equity_df_chart['equity'])
             fig_dd = go.Figure()
             fig_dd.add_trace(go.Scatter(x=dd_df.index, y=dd_df['dd_pct'], mode="lines", name="Drawdown (%)"))
             fig_dd.update_layout(title="Curva de Drawdown (%)", xaxis_title="Fecha", yaxis_title="Drawdown (%)", hovermode="x unified")
             _k = f"{filter_name}_plot_dd" if filter_name else "default_plot_dd"
             st.plotly_chart(fig_dd, use_container_width=True, key=_k)
-            max_dd_pct = dd_df.attrs.get('max_dd_pct', float(dd_df['dd_pct'].min()))
+            max_dd_pct = max_drawdown_pct(equity_df_chart['equity'])
             metrics["Max Drawdown (%)"] = max_dd_pct
 
     with chart_col2:
@@ -287,7 +287,7 @@ def render_global_results(filter_name: str = ""):
             with col3:
                 st.metric(
                     "Max Drawdown",
-                    f"{max_dd_pct:.2f}%",
+                    f"{-max_dd_pct:.2f}%",
                 )
 
     st.markdown("---")


### PR DESCRIPTION
## Summary
- add drawdown_curve_pct and max_drawdown_pct helpers to centralize drawdown logic
- use the new helpers in results and comparison renderers and metrics module
- ensure Max Drawdown metrics store positive values and display with sign in UI

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bde1ce001483248dd9168e2886a986