### PR TITLE
Centralize global metrics and unify drawdown calculations

### DIFF
--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -5,11 +5,11 @@ from pathlib import Path
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
-from agent_core.metrics import compute_max_drawdown_pct
+from agent_core.utils.metrics import compute_drawdown_pct
 
 
-def test_compute_max_drawdown_pct_basic():
+def test_compute_drawdown_pct_basic():
     equity = pd.Series([100, 120, 90, 95, 80, 110])
-    mdd = compute_max_drawdown_pct(equity)
+    mdd = compute_drawdown_pct(equity)
     assert mdd == pytest.approx(33.33, abs=0.01)
 


### PR DESCRIPTION
## Summary
- centralize drawdown and global metric calculations in `agent_core.utils.metrics`
- update Streamlit result and comparison renderers to consume shared metrics and drawdown series
- adjust tests for new metric utilities

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68bdf5e6ae68832498de30c2da966d06