### PR TITLE
feat(crypto): add IB crypto contract utilities and default symbols

### DIFF
--- a/agent_core/ib_crypto_support.py
+++ b/agent_core/ib_crypto_support.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+from ib_insync import Contract
+import re
+import os
+
+DEFAULT_CRYPTO_EXCHANGE = os.getenv("IB_CRYPTO_EXCHANGE", "PAXOS")
+
+def parse_crypto_pair(symbol: str):
+    s = symbol.strip().upper().replace('/', '-').replace('_', '-')
+    if '-' in s:
+        base, quote = s.split('-', 1)
+        return base, quote
+    m = re.match(r'^([A-Z0-9]+)(USD|USDT|USDC|EUR|GBP)$', s)
+    if m:
+        return m.group(1), m.group(2)
+    raise ValueError(f"Símbolo cripto no reconocido: {symbol}")
+
+def build_crypto_contract(symbol: str, exchange: str | None = None) -> Contract:
+    base, quote = parse_crypto_pair(symbol)
+    c = Contract()
+    c.secType = 'CRYPTO'
+    c.symbol = base
+    c.currency = quote
+    c.exchange = exchange or DEFAULT_CRYPTO_EXCHANGE
+    return c

--- a/config/crypto_symbols.py
+++ b/config/crypto_symbols.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+"""Símbolos por defecto para mercado de criptomonedas.
+Se pueden ampliar según disponibilidad en IB (PAXOS).
+"""
+import os
+
+CRYPTO_SYMBOLS = [
+    "BTC-USD",
+    "ETH-USD"
+]
+DEFAULT_CRYPTO = "BTC-USD"
+# Puedes cambiar el exchange por variable de entorno si fuera necesario
+IB_CRYPTO_EXCHANGE = os.getenv("IB_CRYPTO_EXCHANGE", "PAXOS")


### PR DESCRIPTION
## Summary
- add default crypto symbol list and exchange configuration
- provide helpers to parse crypto pairs and build IB CRYPTO contracts

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68c09a23ad288324926dd593d11eb4a9