### PR TITLE
feat(wire): pasar market='crypto' hasta el Data Manager

### DIFF
--- a/agent_core/data_manager.py
+++ b/agent_core/data_manager.py
@@ -244,12 +244,19 @@ class DataManager:
         return {'PMH': pmh if pd.notna(pmh) else None, 'PML': pml if pd.notna(pml) else None}
 
     def get_main_data(self, symbol: str, timeframe: str, sec_type: str, exchange: str, currency: str, rth: bool, what_to_show: str,
-                      download_start_date: datetime.date, download_end_date: datetime.date, 
-                      use_cache=True, **kwargs) -> pd.DataFrame:
+                      download_start_date: datetime.date, download_end_date: datetime.date,
+                      use_cache=True, market: str | None = None, **kwargs) -> pd.DataFrame:
         
         # --- INICIO DE LA LÓGICA DE CACHÉ INTELIGENTE Y DESCARGA POR FRAGMENTOS ---
         
-        contract = self._resolve_contract(symbol, sec_type, exchange, currency, **kwargs)
+        market = market or kwargs.pop('market', None)
+        if market == 'crypto':
+            from agent_core.ib_crypto_support import build_crypto_contract
+            contract = build_crypto_contract(symbol)
+            rth = False
+            what_to_show = 'TRADES'
+        else:
+            contract = self._resolve_contract(symbol, sec_type, exchange, currency, **kwargs)
         all_dfs = []
         current_start = download_start_date
         

--- a/agent_core/ib_crypto_support.py
+++ b/agent_core/ib_crypto_support.py
@@ -1,0 +1,11 @@
+import os
+from ib_insync import Contract
+
+
+def build_crypto_contract(symbol_pair: str) -> Contract:
+    exchange = os.getenv('IB_CRYPTO_EXCHANGE', 'PAXOS')
+    try:
+        symbol, currency = symbol_pair.split('-', 1)
+    except ValueError:
+        raise ValueError("Symbol must be in 'BASE-QUOTE' format like 'ETH-USD'")
+    return Contract(symbol=symbol, secType='CRYPTO', exchange=exchange, currency=currency)

--- a/config.py
+++ b/config.py
@@ -5,6 +5,7 @@ Archivo de configuración central para el Scalping Backtester.
 
 import os
 from pathlib import Path
+import types, sys
 
 # --- Configuración de Conexión a Interactive Brokers ---
 IB_HOST = '127.0.0.1' # Host de TWS o IB Gateway
@@ -63,3 +64,9 @@ INITIAL_CAPITAL = 1000.0
 COMMISSION_PER_TRADE = 0.85
 SLIPPAGE_POINTS = 0.0
 DEFAULT_LEVERAGE = 5
+
+# --- Crypto symbols submodule ---
+crypto_symbols = types.ModuleType("config.crypto_symbols")
+crypto_symbols.CRYPTO_SYMBOLS = ['BTC-USD', 'ETH-USD']
+crypto_symbols.DEFAULT_CRYPTO_SYMBOL = crypto_symbols.CRYPTO_SYMBOLS[0]
+sys.modules[__name__ + ".crypto_symbols"] = crypto_symbols

--- a/ui/app.py
+++ b/ui/app.py
@@ -173,6 +173,7 @@ def load_data_for_backtest(dm: DataManager, exec_tf: str, filter_tf: str) -> tup
     """Carga los datos de ejecución y filtro para un backtest."""
     warmup_period = datetime.timedelta(days=30)
     adjusted_download_start = st.session_state.ui_download_start - warmup_period
+    market_key = 'crypto' if st.session_state.ui_sec_type == 'CRYPTO' else None
     
     common_params = {
         "symbol": st.session_state.ui_symbol, "sec_type": st.session_state.ui_sec_type,
@@ -183,11 +184,11 @@ def load_data_for_backtest(dm: DataManager, exec_tf: str, filter_tf: str) -> tup
     }
 
     with st.spinner(f"Cargando datos (Ejecución: {exec_tf}, Filtro: {filter_tf})..."):
-        df_exec_raw = dm.get_main_data(timeframe=exec_tf, **common_params)
+        df_exec_raw = dm.get_main_data(timeframe=exec_tf, market=market_key, **common_params)
         
         df_filter_raw = pd.DataFrame()
         if filter_tf != exec_tf:
-            df_filter_raw = dm.get_main_data(timeframe=filter_tf, **common_params)
+            df_filter_raw = dm.get_main_data(timeframe=filter_tf, market=market_key, **common_params)
         else:
             # Si son el mismo, evitamos una segunda descarga innecesaria
             df_filter_raw = df_exec_raw.copy()
@@ -286,6 +287,7 @@ def process_loading_state_visual():
     st.session_state.executor = ExecutionSimulator(initial_capital=st.session_state.ui_initial_capital, leverage=st.session_state.ui_leverage)
     with st.spinner("Conectando a IB..."):
         if not dm.connect_ib(): st.error("Fallo la conexión a IB."); st.session_state.app_fsm.transition_to(AppState.ERROR); return
+    market_key = 'crypto' if st.session_state.ui_sec_type == 'CRYPTO' else None
     try:
         lookback_days = datetime.timedelta(days=30)
         adjusted_download_start = st.session_state.ui_download_start - lookback_days
@@ -298,7 +300,8 @@ def process_loading_state_visual():
                 what_to_show=st.session_state.ui_what_to_show,
                 download_start_date=adjusted_download_start,
                 download_end_date=st.session_state.ui_download_end,
-                use_cache=st.session_state.ui_use_cache, primary_exchange=st.session_state.ui_primary_exchange
+                use_cache=st.session_state.ui_use_cache, primary_exchange=st.session_state.ui_primary_exchange,
+                market=market_key
             )
         if st.session_state.all_data_utc.empty: st.warning("No se obtuvieron datos."); st.session_state.app_fsm.transition_to(AppState.CONFIGURING); return
         st.session_state.app_fsm.transition_to(AppState.READY)


### PR DESCRIPTION
## Summary
- Wire market parameter from UI to DataManager and add crypto contract helper
- Provide dynamic crypto symbols submodule
- Handle market-specific IB contract with rth/whatToShow defaults

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python - <<'PY'
import importlib
for m in ['config.crypto_symbols','agent_core.ib_crypto_support']:
    importlib.import_module(m)
print('OK imports')
PY`
- `export IB_CRYPTO_EXCHANGE=PAXOS; python - <<'PY'
from agent_core.ib_crypto_support import build_crypto_contract
c = build_crypto_contract('ETH-USD')
assert c.secType=='CRYPTO' and c.symbol=='ETH' and c.currency=='USD'
print('OK contract ETH-USD ->', c)
PY`


------
https://chatgpt.com/codex/tasks/task_e_68c09e7e193c83249c5c04c3d027e4a6