### PR TITLE
Add liquidity window profiles and stamping helper

### DIFF
--- a/shared/liquidity_profiles.py
+++ b/shared/liquidity_profiles.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+# Ventanas de liquidez sugeridas por mercado (HH:MM en tz indicada)
+LIQUIDITY_PROFILES = {
+    'stocks': {
+        'us_equity_open':   {'tz': 'America/New_York', 'start': '09:30', 'minutes': 5},
+        'us_first_30m':     {'tz': 'America/New_York', 'start': '09:30', 'minutes': 30}
+    },
+    'forex': {
+        'london_open':      {'tz': 'Europe/London',    'start': '08:00', 'minutes': 5},
+        'ny_overlap':       {'tz': 'America/New_York', 'start': '08:00', 'minutes': 60},
+        'daily_open_roll':  {'tz': 'America/New_York', 'start': '17:00', 'minutes': 5}  # rollover FX
+    },
+    'crypto': {
+        'daily_open_utc':   {'tz': 'UTC',              'start': '00:00', 'minutes': 5},
+        'us_equity_open':   {'tz': 'America/New_York', 'start': '09:30', 'minutes': 5},
+        'asia_open':        {'tz': 'Asia/Tokyo',       'start': '09:00', 'minutes': 5}
+    }
+}

--- a/shared/liquidity_stamper.py
+++ b/shared/liquidity_stamper.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+import pandas as pd
+from datetime import time, timedelta
+from .liquidity_profiles import LIQUIDITY_PROFILES
+
+
+def stamp_liquidity_window(df: pd.DataFrame, market: str, window_key: str | None) -> pd.DataFrame:
+    if df.empty:
+        return df
+    m = (market or '').lower()
+    profiles = LIQUIDITY_PROFILES.get(m, {})
+    # Fallback sensato por mercado
+    if not window_key or window_key not in profiles:
+        window_key = {
+            'stocks': 'us_equity_open',
+            'forex':  'london_open',
+            'crypto': 'us_equity_open'  # si quieres replicar impulso USA en cripto
+        }.get(m, 'us_equity_open')
+    cfg = profiles[window_key]
+    tz = cfg['tz']
+    hh, mm = map(int, cfg['start'].split(':'))
+    span = int(cfg['minutes'])
+
+    df = df.copy()
+    if df.index.tz is None:
+        df = df.tz_localize('UTC')
+    local = df.index.tz_convert(tz)
+
+    df['session_date'] = pd.to_datetime(local.date)
+    df['in_session'] = True
+
+    start_t = time(hh, mm)
+    # soportar saltos > 60 min de forma simple
+    end_local = (local.floor('T').map(lambda ts: ts.replace(hour=hh, minute=mm, second=0, microsecond=0)) + pd.Timedelta(minutes=span)).dt.time
+    df['in_opening_window'] = (local.time >= start_t) & (local.time < end_local)
+
+    # Meta para diagnósticos
+    df.attrs['liquidity_window'] = {'market': m, 'window_key': window_key, 'tz': tz, 'start': cfg['start'], 'minutes': span}
+    return df


### PR DESCRIPTION
## Summary
- define preset liquidity windows for stocks, forex, and crypto
- add utility to stamp liquidity session information on DataFrames

## Testing
- `python -m pytest` *(fails: No module named 'pandas')*


------
https://chatgpt.com/codex/tasks/task_e_68c0e6dec308832485b88630768da1ba