### PR TITLE
Wire liquidity window into analyzer

### DIFF
--- a/agent_core/main.py
+++ b/agent_core/main.py
@@ -5,6 +5,7 @@ import pandas as pd
 import json
 import numpy as np
 import logging
+from shared.liquidity_stamper import stamp_liquidity_window
 
 from strategies.opening_br_strategy import OpeningBreakRetestStrategy
 
@@ -61,7 +62,7 @@ deterministic_crew = Crew(
     verbose=True
 )
 
-def handle_signal_request(historical_data: pd.DataFrame, current_levels: dict, reset_strategy: bool = False, ema_filter_mode: str = "Desactivado", daily_candle_index: int = -1) -> str | dict:
+def handle_signal_request(historical_data: pd.DataFrame, current_levels: dict, reset_strategy: bool = False, ema_filter_mode: str = "Desactivado", daily_candle_index: int = -1, *, or_window: str | None = None, market: str | None = None) -> str | dict:
     """
     Función principal que recibe la solicitud, actualiza la estrategia y obtiene la señal.
     """
@@ -71,6 +72,9 @@ def handle_signal_request(historical_data: pd.DataFrame, current_levels: dict, r
 
     if historical_data is None or historical_data.empty:
         return 'HOLD'
+
+    if ('in_opening_window' not in historical_data.columns) or or_window:
+        historical_data = stamp_liquidity_window(historical_data, market or 'stocks', or_window)
 
     obr_strategy.ema_filter_mode = ema_filter_mode.capitalize()
     obr_strategy.use_ema_filter = obr_strategy.ema_filter_mode != 'Desactivado'

--- a/agent_core/technical_analyzer.py
+++ b/agent_core/technical_analyzer.py
@@ -4,32 +4,41 @@ Módulo para calcular indicadores técnicos y enriquecer los DataFrames de merca
 """
 import pandas as pd
 import logging
+from shared.liquidity_stamper import stamp_liquidity_window
 
 logger = logging.getLogger(__name__)
 
 def add_technical_indicators(
-    df_exec: pd.DataFrame, 
-    df_filter: pd.DataFrame | None = None, 
-    ema_periods: list[int] = [9, 21, 50]
+    df_exec: pd.DataFrame,
+    df_filter: pd.DataFrame | None = None,
+    ema_periods: list[int] = [9, 21, 50],
+    *,
+    market: str | None = None,
+    or_window: str | None = None,
 ) -> pd.DataFrame:
     """
-    Añade indicadores técnicos (EMAs) a un DataFrame de ejecución.
-    
+    Añade indicadores técnicos (EMAs) y columnas de ventana de liquidez a un DataFrame de ejecución.
+
     Args:
         df_exec (pd.DataFrame): DataFrame con el timeframe de ejecución (ej. 1 min).
-        df_filter (pd.DataFrame | None): DataFrame con el timeframe para el filtro EMA. 
-                                         Si es None o el mismo que df_exec, las EMAs se 
+        df_filter (pd.DataFrame | None): DataFrame con el timeframe para el filtro EMA.
+                                         Si es None o el mismo que df_exec, las EMAs se
                                          calculan sobre df_exec.
         ema_periods (list[int]): Lista de períodos para las EMAs a calcular.
-
+        market (str | None): Mercado para determinar la ventana de liquidez.
+        or_window (str | None): Clave de la ventana de apertura a estampar.
     Returns:
         pd.DataFrame: El DataFrame df_exec enriquecido con las columnas de los indicadores.
     """
     if df_exec is None or df_exec.empty:
         return pd.DataFrame()
 
+    # Estampar ventana de liquidez si aún no existe o si se especifica una nueva ventana
+    if ('in_opening_window' not in df_exec.columns) or or_window:
+        df_exec = stamp_liquidity_window(df_exec, market or '', or_window)
+
     df_to_enrich = df_exec.copy()
-    
+
     source_df_for_emas = df_exec if df_filter is None or df_filter.empty else df_filter
     timeframe_source_name = "ejecución" if source_df_for_emas is df_exec else "superior"
     logger.info(f"Calculando EMAs en timeframe de {timeframe_source_name}.")
@@ -39,29 +48,34 @@ def add_technical_indicators(
     for period in ema_periods:
         col_name = f'EMA_{period}'
         ema_cols[col_name] = source_df_for_emas['close'].ewm(span=period, adjust=False).mean()
-    
+
     df_emas = pd.DataFrame(ema_cols, index=source_df_for_emas.index)
 
-    # --- INICIO DE LA MODIFICACIÓN CLAVE ---
-    
-    # Paso 1: Unir los DataFrames. Esto crea valores NaN en df_to_enrich donde no hay una EMA 
-    # del timeframe superior que coincida exactamente.
+    df_with_gaps = df_to_enrich.join(df_emas, how='left')
+
     if source_df_for_emas is not df_exec:
-        df_with_gaps = df_to_enrich.join(df_emas, how='left')
-    else: # Si es el mismo timeframe, simplemente unir. No habrá gaps.
-        df_with_gaps = df_to_enrich.join(df_emas, how='left')
-        return df_with_gaps
+        # Paso 2: Aplicar el forward-fill (ffill) de manera segmentada por día.
+        # Se agrupan los datos por la fecha del índice y se aplica ffill() a cada grupo.
+        # Esto previene que el último valor de un día se "arrastre" al inicio del día siguiente.
+        if not isinstance(df_with_gaps.index, pd.DatetimeIndex):
+            logger.warning("El índice del DataFrame no es de tipo DatetimeIndex. Intentando convertir.")
+            df_with_gaps.index = pd.to_datetime(df_with_gaps.index, utc=True)
 
-    # Paso 2: Aplicar el forward-fill (ffill) de manera segmentada por día.
-    # Se agrupan los datos por la fecha del índice y se aplica ffill() a cada grupo.
-    # Esto previene que el último valor de un día se "arrastre" al inicio del día siguiente.
-    if not isinstance(df_with_gaps.index, pd.DatetimeIndex):
-        logger.warning("El índice del DataFrame no es de tipo DatetimeIndex. Intentando convertir.")
-        df_with_gaps.index = pd.to_datetime(df_with_gaps.index, utc=True)
-
-    df_enriched_corrected = df_with_gaps.groupby(df_with_gaps.index.date).ffill()
-    
-    # --- FIN DE LA MODIFICACIÓN CLAVE ---
+        df_result = df_with_gaps.groupby(df_with_gaps.index.date).ffill()
+    else:
+        df_result = df_with_gaps
 
     logger.info("DataFrame enriquecido con indicadores técnicos (corrección anti-fuga aplicada).")
-    return df_enriched_corrected
+
+    # Log de diagnóstico de la ventana de liquidez
+    try:
+        meta = df_exec.attrs.get('liquidity_window', {})
+        logger.info(
+            f"DIAG-LIQ: market={meta.get('market')} "
+            f"key={meta.get('window_key')} tz={meta.get('tz')} "
+            f"start={meta.get('start')} minutes={meta.get('minutes')}"
+        )
+    except Exception:
+        pass
+
+    return df_result

--- a/tools/run_backtest.py
+++ b/tools/run_backtest.py
@@ -60,7 +60,7 @@ def run_backtest(symbol: str, timeframe: str, market: str, limit_days: int, out_
         out_path.write_text(json.dumps(output, indent=2))
         return
 
-    df_enriched = add_technical_indicators(df_exec, df_exec)
+    df_enriched = add_technical_indicators(df_exec, df_exec, market=market)
 
     unique_dates = df_enriched.index.normalize().unique()
     all_trades = []


### PR DESCRIPTION
## Summary
- Stamp selected liquidity window in technical analyzer and log diagnostics
- Forward OR window selection through UI and signal handler
- Allow CLI backtests to specify market for liquidity window defaults

## Testing
- `pytest tests/test_drawdown_unificado.py -q`
- `pytest tests/test_forex_fallback.py -q` *(fails: session terminated)*
- `pytest tests/test_forex_smoke.py -q` *(fails: session terminated)*

------
https://chatgpt.com/codex/tasks/task_e_68c0e96c0c3083249fedd9e7b2416135