### PR TITLE
fix(ui): evitar reasignar st.session_state['or_window'] tras el widget

### DIFF
--- a/ui/app.py
+++ b/ui/app.py
@@ -669,7 +669,6 @@ with st.sidebar:
             index=profile_keys.index(current_key) if current_key in profile_keys else 0,
             key="or_window",
         )
-        st.session_state["or_window"] = or_window
 
         if st.session_state.ui_market == "forex":
             symbol_options = config.FOREX_SYMBOLS


### PR DESCRIPTION
## Summary
- evita la reasignación manual de `st.session_state['or_window']` después del selectbox

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c0ed09e8048324b5c4ffcbf3f55e7b