### PR TITLE
Fix liquidity stamper mask and align OR stamping across dataframes

### DIFF
--- a/shared/liquidity_stamper.py
+++ b/shared/liquidity_stamper.py
@@ -1,39 +1,65 @@
+
 # -*- coding: utf-8 -*-
 import pandas as pd
-from datetime import time, timedelta
+import numpy as np
+from datetime import time
 from .liquidity_profiles import LIQUIDITY_PROFILES
 
 
+def _add_minutes_to_time(hh: int, mm: int, span: int) -> time:
+    total = (hh * 60 + mm + int(span)) % 1440
+    return time(total // 60, total % 60)
+
+
 def stamp_liquidity_window(df: pd.DataFrame, market: str, window_key: str | None) -> pd.DataFrame:
-    if df.empty:
+    if df is None or df.empty:
         return df
+
     m = (market or '').lower()
     profiles = LIQUIDITY_PROFILES.get(m, {})
-    # Fallback sensato por mercado
     if not window_key or window_key not in profiles:
         window_key = {
             'stocks': 'us_equity_open',
-            'forex':  'london_open',
-            'crypto': 'us_equity_open'  # si quieres replicar impulso USA en cripto
+            'forex': 'london_open',
+            'crypto': 'us_equity_open'
         }.get(m, 'us_equity_open')
+
     cfg = profiles[window_key]
     tz = cfg['tz']
     hh, mm = map(int, cfg['start'].split(':'))
     span = int(cfg['minutes'])
 
+    # Asegurar índice con tz y convertir a tz del perfil
     df = df.copy()
     if df.index.tz is None:
-        df = df.tz_localize('UTC')
-    local = df.index.tz_convert(tz)
+        df.index = df.index.tz_localize('UTC')
+    local_idx = df.index.tz_convert(tz)
 
-    df['session_date'] = pd.to_datetime(local.date)
-    df['in_session'] = True
+    # Campos estándar para niveles
+    df['session_date'] = pd.to_datetime(local_idx.date)
+    df['in_session'] = True  # 24/7; si necesitas RTH, filtra fuera de esta función
 
+    # Construir máscara sin usar .dt sobre DatetimeIndex
     start_t = time(hh, mm)
-    # soportar saltos > 60 min de forma simple
-    end_local = (local.floor('T').map(lambda ts: ts.replace(hour=hh, minute=mm, second=0, microsecond=0)) + pd.Timedelta(minutes=span)).dt.time
-    df['in_opening_window'] = (local.time >= start_t) & (local.time < end_local)
+    end_t = _add_minutes_to_time(hh, mm, span)
 
-    # Meta para diagnósticos
-    df.attrs['liquidity_window'] = {'market': m, 'window_key': window_key, 'tz': tz, 'start': cfg['start'], 'minutes': span}
+    # Vectorizar las horas del índice local
+    times = np.array([t.time() for t in local_idx])  # array de datetime.time
+
+    if end_t > start_t:
+        in_open = (times >= start_t) & (times < end_t)
+    else:
+        # Ventana cruza medianoche: [start_t, 24h) U [0h, end_t)
+        in_open = (times >= start_t) | (times < end_t)
+
+    df['in_opening_window'] = in_open
+
+    # Metadatos de diagnóstico
+    df.attrs['liquidity_window'] = {
+        'market': m,
+        'window_key': window_key,
+        'tz': tz,
+        'start': cfg['start'],
+        'minutes': span
+    }
     return df


### PR DESCRIPTION
## Summary
- Fix liquidity stamper to avoid `.dt` AttributeError, handle midnight crossing, and remove `floor('T')`
- Stamp opening range window consistently on both execution and filter dataframes with diagnostic logging
- Adjust df_filter stamping block

## Testing
- `python - <<'PY'
import pandas as pd
from shared.liquidity_stamper import stamp_liquidity_window
idx = pd.date_range('2025-08-10', periods=1440, freq='min', tz='UTC')
df = pd.DataFrame({'close':1.0}, index=idx)
out = stamp_liquidity_window(df, 'crypto', 'us_equity_open')
print('cols:', set(out.columns))
print('OR sum:', int(out['in_opening_window'].sum()))
print('attrs:', out.attrs.get('liquidity_window'))
PY`
- `git grep -n "stamp_liquidity_window(df_exec" agent_core/technical_analyzer.py`
- `git grep -n "df_filter = stamp_liquidity_window" agent_core/technical_analyzer.py`
- `git grep -n "DIAG-LIQ" agent_core/technical_analyzer.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c0f0eed7748324b47f047da637a0c4