### PR TITLE
feat(exact): align engines under EXACT_MATCH_MODE

### DIFF
--- a/agent_core/execution.py
+++ b/agent_core/execution.py
@@ -7,13 +7,25 @@ y el ciclo de vida completo de cada operación individual a través de una FSM.
 import pandas as pd
 import logging
 from decimal import Decimal, ROUND_HALF_UP, InvalidOperation
-import pytz
-import math
 import uuid
+import sys
+from typing import Callable, Optional
 
 # Importaciones de módulos compartidos
 from shared.timezone_handler import ensure_timezone_utc
 from shared.fsm import FSM, TradeState
+from shared.config import (
+    EXACT_MATCH_MODE,
+    TRADING_WINDOW_START,
+    TRADING_WINDOW_END,
+    FORCE_CLOSE_TIME,
+    SLIPPAGE_MODE,
+    SLIPPAGE_VALUE,
+    ALLOW_FRACTIONAL_SIZE_CRYPTO,
+)
+from shared.time_windows import is_trading_window, is_force_close
+from shared.slippage import apply_slippage
+from agent_core.position_sizing import compute_position_size
 
 logger = logging.getLogger(__name__)
 
@@ -35,14 +47,14 @@ class Trade:
     Representa una única operación de trading con su propio ciclo de vida gestionado por una FSM.
     Cada instancia de esta clase es una operación independiente.
     """
-    def __init__(self, direction: str, entry_time, entry_price: Decimal, size: int,
+    def __init__(self, direction: str, entry_time, entry_price: Decimal, size: Decimal | int | float,
                  sl_price: Decimal, tp_price: Decimal, entry_emas: dict, level_triggered: str | None):
         self.id = uuid.uuid4()
         self.fsm = FSM(TradeState.ACTIVE)
         self.direction = direction
         self.entry_time = entry_time
         self.entry_price = entry_price
-        self.size = size
+        self.size = size if isinstance(size, Decimal) else Decimal(str(size))
         self.initial_sl_price = sl_price
         self.initial_tp_price = tp_price
         self.current_sl_price = sl_price
@@ -88,7 +100,7 @@ class Trade:
         """Convierte la información del trade a un diccionario para los registros y la UI."""
         return {
             "entry_time": self.entry_time, "exit_time": self.exit_time, "direction": self.direction,
-            "size": self.size, "entry_price": float(self.entry_price) if not self.entry_price.is_nan() else None,
+            "size": float(self.size), "entry_price": float(self.entry_price) if not self.entry_price.is_nan() else None,
             "exit_price": float(self.exit_price) if not self.exit_price.is_nan() else None,
             "pnl_gross": float(self.pnl_gross) if not self.pnl_gross.is_nan() else None,
             "commission": float(self.commission) if not self.commission.is_nan() else None,
@@ -123,8 +135,14 @@ class ExecutionSimulator:
 
         self.closed_trades = []
         self.equity_history = []
-        
+
         self.account_fsm = FSM(TradeState.FLAT)
+
+        self.market: str = 'stocks'
+        self.lot_step: Optional[float] = None
+        self.min_qty: Optional[float] = None
+        self.allow_fractional_crypto: bool = ALLOW_FRACTIONAL_SIZE_CRYPTO
+        self._strategy_reset_hook: Optional[Callable[[], None]] = None
 
         logger.info(f"ExecutionSimulator (FSM) inicializado: Capital={self.initial_capital:.2f}, Leverage={self.leverage}:1")
 
@@ -134,13 +152,65 @@ class ExecutionSimulator:
         self.leverage = max(1, int(new_leverage))
         logger.info(f"Apalancamiento actualizado de {old_leverage}:1 a {self.leverage}:1.")
 
+    def configure_market(
+        self,
+        *,
+        market: Optional[str] = None,
+        lot_step: Optional[float] = None,
+        min_qty: Optional[float] = None,
+        allow_fractional_crypto: Optional[bool] = None,
+    ) -> None:
+        """Configura metadatos del mercado para cálculo de tamaño."""
+        if market:
+            self.market = market.lower()
+        if lot_step is not None:
+            self.lot_step = float(lot_step) if lot_step else None
+        if min_qty is not None:
+            self.min_qty = float(min_qty) if min_qty else None
+        if allow_fractional_crypto is not None:
+            self.allow_fractional_crypto = bool(allow_fractional_crypto)
+
+    def set_strategy_reset_hook(self, callback: Callable[[], None] | None) -> None:
+        """Permite registrar un callback para resetear la estrategia tras cerrar trades."""
+        self._strategy_reset_hook = callback
+
+    def _ensure_strategy_reset_hook(self) -> Optional[Callable[[], None]]:
+        if self._strategy_reset_hook is not None:
+            return self._strategy_reset_hook
+
+        strategy = getattr(self, 'obr_strategy', None)
+        if strategy and hasattr(strategy, 'reset'):
+            self._strategy_reset_hook = lambda s=strategy: s.reset()
+            return self._strategy_reset_hook
+
+        main_module = sys.modules.get('agent_core.main')
+        strategy = getattr(main_module, 'obr_strategy', None) if main_module else None
+        if strategy and hasattr(strategy, 'reset'):
+            self._strategy_reset_hook = lambda s=strategy: s.reset()
+        return self._strategy_reset_hook
+
+    def _on_trade_closed(self) -> None:
+        if not EXACT_MATCH_MODE:
+            return
+        hook = self._ensure_strategy_reset_hook()
+        if callable(hook):
+            try:
+                hook()
+            except Exception as exc:  # pragma: no cover - defensive guard
+                logger.error("Error reseteando estrategia tras cierre de trade: %s", exc, exc_info=True)
+
     def _get_execution_price(self, target_price: float, signal_type_for_slippage: str) -> Decimal:
         price_dec = quantize(target_price)
         if price_dec.is_nan(): return price_dec
+        signal_upper = (signal_type_for_slippage or '').upper()
+        if EXACT_MATCH_MODE:
+            side = 'buy' if signal_upper in ['BUY', 'COVER_SHORT'] else 'sell'
+            slipped = apply_slippage(float(price_dec), side, SLIPPAGE_MODE, SLIPPAGE_VALUE)
+            return quantize(slipped)
         if self.slippage_points > Decimal('0'):
-            if signal_type_for_slippage in ['BUY', 'COVER_SHORT']:
+            if signal_upper in ['BUY', 'COVER_SHORT']:
                 return price_dec + self.slippage_points
-            elif signal_type_for_slippage in ['SELL', 'SHORT']:
+            if signal_upper in ['SELL', 'SHORT']:
                 return max(Decimal('0.0'), price_dec - self.slippage_points)
         return price_dec
 
@@ -159,17 +229,24 @@ class ExecutionSimulator:
             logger.warning(f"Precio de entrada inválido: {entry_exec_price}. No se abre posición.")
             return None
             
-        buying_power = current_equity * Decimal(self.leverage)
-        calculated_size = math.floor(buying_power / entry_exec_price)
+        size_value = compute_position_size(
+            market=self.market,
+            equity=float(current_equity),
+            leverage=float(self.leverage),
+            entry_price=float(entry_exec_price),
+            lot_step=self.lot_step,
+            min_qty=self.min_qty,
+            allow_fractional_crypto=self.allow_fractional_crypto,
+        )
 
-        if calculated_size <= 0:
+        if size_value == 0:
             logger.info("Tamaño de posición calculado es 0. No se abre trade.")
             return None
 
         if self.cash < self.commission_per_side:
             logger.warning("Cash insuficiente para cubrir la comisión de entrada.")
             return None
-        
+
         # --- LÓGICA DE SL/TP SIMPLIFICADA ---
         # Ahora se confía 100% en los valores que vienen del diccionario de la señal.
         sl_price = quantize(signal_data.get('sl_price'))
@@ -183,23 +260,31 @@ class ExecutionSimulator:
         self.cash -= self.commission_per_side
         self.account_fsm.transition_to(TradeState.ACTIVE)
         
+        position_size_dec = Decimal(str(size_value))
+
         self.current_trade = Trade(
             direction='LONG' if signal_type == 'BUY' else 'SHORT',
             entry_time=timestamp,
             entry_price=entry_exec_price,
-            size=calculated_size,
+            size=position_size_dec,
             sl_price=sl_price,
             tp_price=tp_price,
             entry_emas=signal_data.get('emas', {}),
             level_triggered=signal_data.get('level')
         )
-        
-        logger.info(f"TRADE ABIERTO ({self.current_trade.direction}): Size={self.current_trade.size} @ {self.current_trade.entry_price:.4f}")
+
+        size_display = float(position_size_dec)
+        logger.info(
+            "TRADE ABIERTO (%s): Size=%s @ %.4f",
+            self.current_trade.direction,
+            f"{size_display:g}",
+            float(self.current_trade.entry_price),
+        )
 
         marker_color = 'lime' if self.current_trade.direction == 'LONG' else 'magenta'
         marker_shape = 'arrowUp' if self.current_trade.direction == 'LONG' else 'arrowDown'
         marker_position = 'belowBar' if self.current_trade.direction == 'LONG' else 'aboveBar'
-        marker_text = f"{self.current_trade.direction} {calculated_size} ({self.current_trade.level_triggered or ''})".strip()
+        marker_text = f"{self.current_trade.direction} {size_display:g} ({self.current_trade.level_triggered or ''})".strip()
         return {'marker': {'time': timestamp, 'position': marker_position, 'shape': marker_shape, 'color': marker_color, 'text': marker_text}}
 
     def _close_current_position(self, timestamp, exit_exec_price: Decimal, exit_reason: str) -> dict | None:
@@ -232,7 +317,9 @@ class ExecutionSimulator:
 
         self.current_trade = None
         self.account_fsm.transition_to(TradeState.FLAT)
-        
+
+        self._on_trade_closed()
+
         return result_marker
 
     def process_signal(self, signal, candle: pd.Series) -> dict | None:
@@ -250,9 +337,13 @@ class ExecutionSimulator:
             self._update_equity_history(None, timestamp)
             return None
 
+        allow_entry = True
+        if EXACT_MATCH_MODE and not is_trading_window(timestamp, TRADING_WINDOW_START, TRADING_WINDOW_END):
+            allow_entry = False
+
         if self.account_fsm.is_in_state(TradeState.ACTIVE) and self.current_trade:
             self.current_trade.update_on_candle(candle)
-            
+
             exit_reason, exit_price_trigger = self._check_sl_tp(candle)
             if exit_reason:
                 exit_signal_type = 'SELL' if self.current_trade.direction == 'LONG' else 'BUY'
@@ -270,6 +361,14 @@ class ExecutionSimulator:
                     self._update_equity_history(close_price_float, timestamp)
                     return result
 
+            if EXACT_MATCH_MODE and is_force_close(timestamp, FORCE_CLOSE_TIME):
+                exit_signal_type = 'SELL' if self.current_trade.direction == 'LONG' else 'BUY'
+                exit_exec_price = self._get_execution_price(close_price_float, exit_signal_type)
+                if not exit_exec_price.is_nan():
+                    result = self._close_current_position(timestamp, exit_exec_price, "ForceClose")
+                    self._update_equity_history(close_price_float, timestamp)
+                    return result
+
             signal_type = signal if isinstance(signal, str) else signal.get('type', 'HOLD')
             if (self.current_trade.direction == 'LONG' and signal_type == 'SELL') or \
                (self.current_trade.direction == 'SHORT' and signal_type == 'BUY'):
@@ -280,7 +379,7 @@ class ExecutionSimulator:
                     self._update_equity_history(close_price_float, timestamp)
                     return result
 
-        if self.account_fsm.is_in_state(TradeState.FLAT) and isinstance(signal, dict):
+        if allow_entry and self.account_fsm.is_in_state(TradeState.FLAT) and isinstance(signal, dict):
             signal_type = signal.get('type', 'HOLD').upper()
             if signal_type in ['BUY', 'SELL']:
                 result = self._open_position(signal, candle)

--- a/agent_core/position_sizing.py
+++ b/agent_core/position_sizing.py
@@ -1,0 +1,57 @@
+"""Position sizing utilities shared across execution engines."""
+from __future__ import annotations
+
+from decimal import Decimal
+from math import floor
+from typing import Optional
+
+
+def _quantize_step(value: float, step: Optional[float]) -> float:
+    if not step or step <= 0:
+        return float(value)
+    multiples = floor(float(value) / float(step))
+    return float(multiples * float(step))
+
+
+def compute_position_size(
+    market: str,
+    equity: float,
+    leverage: float,
+    entry_price: float,
+    lot_step: float | None,
+    min_qty: float | None,
+    allow_fractional_crypto: bool,
+) -> int | float:
+    """Compute the desired position size following the fast-engine policy."""
+    if equity <= 0 or leverage <= 0 or entry_price <= 0:
+        return 0
+
+    notional = float(equity) * float(leverage)
+    if notional <= 0:
+        return 0
+
+    raw_size = notional / float(entry_price)
+    market_lower = (market or "").lower()
+    fractional_allowed = market_lower == "crypto" and allow_fractional_crypto
+
+    size = _quantize_step(raw_size, lot_step if fractional_allowed else lot_step or 1.0)
+
+    if not fractional_allowed:
+        size = float(floor(size)) if lot_step is None or lot_step == 1 else size
+
+    if min_qty and min_qty > 0 and size < float(min_qty):
+        return 0
+
+    if size <= 0:
+        return 0
+
+    if fractional_allowed:
+        return float(size)
+
+    quantized = Decimal(str(size))
+    if quantized == quantized.to_integral():
+        return int(quantized)
+    return float(quantized)
+
+
+__all__ = ["compute_position_size"]

--- a/shared/config.py
+++ b/shared/config.py
@@ -1,0 +1,20 @@
+"""Shared configuration flags for reproducibility across execution engines."""
+from __future__ import annotations
+
+EXACT_MATCH_MODE: bool = True
+TRADING_WINDOW_START: str = "09:30"
+TRADING_WINDOW_END: str = "11:30"
+FORCE_CLOSE_TIME: str = "13:00"
+SLIPPAGE_MODE: str = "points"  # 'points' | 'percent' | 'none'
+SLIPPAGE_VALUE: float = 0.0      # 0 para equivalencia exacta por defecto
+ALLOW_FRACTIONAL_SIZE_CRYPTO: bool = True
+
+__all__ = [
+    "EXACT_MATCH_MODE",
+    "TRADING_WINDOW_START",
+    "TRADING_WINDOW_END",
+    "FORCE_CLOSE_TIME",
+    "SLIPPAGE_MODE",
+    "SLIPPAGE_VALUE",
+    "ALLOW_FRACTIONAL_SIZE_CRYPTO",
+]

--- a/shared/slippage.py
+++ b/shared/slippage.py
@@ -1,0 +1,41 @@
+"""Slippage helpers shared by the fast and step-by-step engines."""
+from __future__ import annotations
+
+from typing import Literal
+
+Side = Literal["buy", "sell"]
+Mode = Literal["points", "percent", "none"]
+
+
+def apply_slippage(price: float, side: Side, mode: Mode, value: float) -> float:
+    """Apply slippage to *price* according to *side* and *mode*.
+
+    A ``buy`` order worsens the fill by increasing the price, while a ``sell`` order
+    worsens it by decreasing the price. When ``mode`` is ``'none'`` or ``value`` is
+    zero the input price is returned unchanged.
+    """
+    if price is None:
+        raise ValueError("Price must be provided to compute slippage")
+
+    mode_normalized = (mode or "none").lower()
+    side_normalized = (side or "").lower()
+    if mode_normalized == "none" or value == 0:
+        return float(price)
+    if side_normalized not in {"buy", "sell"}:
+        raise ValueError(f"Unsupported side '{side}'. Expected 'buy' or 'sell'.")
+
+    slippage_amount: float
+    if mode_normalized == "points":
+        slippage_amount = abs(float(value))
+    elif mode_normalized == "percent":
+        slippage_amount = abs(float(price) * float(value))
+    else:
+        raise ValueError(f"Unsupported slippage mode '{mode}'.")
+
+    if side_normalized == "buy":
+        return float(price) + slippage_amount
+    adjusted = float(price) - slippage_amount
+    return adjusted if adjusted > 0 else 0.0
+
+
+__all__ = ["apply_slippage"]

--- a/shared/time_windows.py
+++ b/shared/time_windows.py
@@ -1,0 +1,74 @@
+"""Time window helpers shared between execution engines."""
+from __future__ import annotations
+
+from datetime import datetime, time
+
+import pandas as pd
+
+try:  # Python 3.11+ stdlib
+    from zoneinfo import ZoneInfo  # type: ignore
+except ImportError:  # pragma: no cover - fallback for environments without zoneinfo
+    from pytz import timezone as ZoneInfo  # type: ignore
+
+
+def _parse_time(value: str | time) -> time:
+    if isinstance(value, time):
+        return value
+    if not isinstance(value, str):
+        raise TypeError("Trading window times must be provided as HH:MM strings or datetime.time instances")
+    hour, minute = value.split(":", 1)
+    return time(int(hour), int(minute))
+
+
+def _ensure_local_timestamp(ts: datetime | pd.Timestamp, tz: str) -> pd.Timestamp:
+    if ts is None:
+        raise ValueError("Timestamp required for time window evaluation")
+    timestamp = pd.Timestamp(ts)
+    try:
+        tzinfo = ZoneInfo(tz)
+    except Exception as exc:  # pragma: no cover - defensive guard
+        raise ValueError(f"Invalid timezone '{tz}'") from exc
+
+    if timestamp.tzinfo is None:
+        timestamp = timestamp.tz_localize(tzinfo)
+    else:
+        timestamp = timestamp.tz_convert(tzinfo)
+    return timestamp
+
+
+def _time_to_minutes(value: time) -> int:
+    return value.hour * 60 + value.minute
+
+
+def is_trading_window(
+    ts: datetime | pd.Timestamp,
+    start: str | time,
+    end: str | time,
+    tz: str = "America/New_York",
+) -> bool:
+    """Return True when *ts* falls within the inclusive [start, end] trading window."""
+    start_time = _parse_time(start)
+    end_time = _parse_time(end)
+    ts_local = _ensure_local_timestamp(ts, tz)
+    current_minutes = ts_local.hour * 60 + ts_local.minute
+    start_minutes = _time_to_minutes(start_time)
+    end_minutes = _time_to_minutes(end_time)
+
+    if start_minutes <= end_minutes:
+        return start_minutes <= current_minutes <= end_minutes
+    # Overnight windows (e.g., 22:00 -> 02:00)
+    return current_minutes >= start_minutes or current_minutes <= end_minutes
+
+
+def is_force_close(
+    ts: datetime | pd.Timestamp,
+    force_time: str | time,
+    tz: str = "America/New_York",
+) -> bool:
+    """Return True when the timestamp is greater than or equal to the configured force-close time."""
+    force = _parse_time(force_time)
+    ts_local = _ensure_local_timestamp(ts, tz)
+    return (ts_local.hour, ts_local.minute) >= (force.hour, force.minute)
+
+
+__all__ = ["is_trading_window", "is_force_close"]

--- a/strategies/vectorized_obr_exact.py
+++ b/strategies/vectorized_obr_exact.py
@@ -6,14 +6,29 @@ from typing import Dict, Tuple, Optional
 
 # Usamos la MISMA estrategia paso-a-paso para garantizar equivalencia exacta
 from .opening_br_strategy import OpeningBreakRetestStrategy
+from shared.config import (
+    EXACT_MATCH_MODE,
+    SLIPPAGE_MODE,
+    SLIPPAGE_VALUE,
+    ALLOW_FRACTIONAL_SIZE_CRYPTO,
+    TRADING_WINDOW_START,
+    TRADING_WINDOW_END,
+    FORCE_CLOSE_TIME,
+)
+from shared.slippage import apply_slippage
+from shared.time_windows import is_trading_window, is_force_close
+from agent_core.position_sizing import compute_position_size
 
 def _is_trading_window(ts: pd.Timestamp) -> bool:
-    """ Ventana de trading del motor rápido: 09:30–11:30 (hora de la vela). """
+    if EXACT_MATCH_MODE:
+        return is_trading_window(ts, TRADING_WINDOW_START, TRADING_WINDOW_END)
     h, m = ts.hour, ts.minute
     return (h == 9 and m >= 30) or (h == 10) or (h == 11 and m <= 30)
 
+
 def _force_close_time(ts: pd.Timestamp) -> bool:
-    """ Cierre forzado del motor rápido a partir de las 13:00. """
+    if EXACT_MATCH_MODE:
+        return is_force_close(ts, FORCE_CLOSE_TIME)
     return ts.hour >= 13
 
 def _to_epoch_seconds(ts: pd.Timestamp) -> float:
@@ -118,18 +133,27 @@ def run_fast_backtest_exact(
         row = df.iloc[i]
 
         if direction != 0:
-            is_closed, exit_reason, exit_price = False, 0, 0.0
+            is_closed, exit_reason = False, 0
+            exit_price_raw = 0.0
             if direction == 1:
-                if row["high"] >= current_tp: is_closed, exit_price, exit_reason = True, float(current_tp), 1
-                elif row["close"] <= current_sl: is_closed, exit_price, exit_reason = True, float(current_sl), 2
+                if row["high"] >= current_tp:
+                    is_closed, exit_price_raw, exit_reason = True, float(current_tp), 1
+                elif row["close"] <= current_sl:
+                    is_closed, exit_price_raw, exit_reason = True, float(current_sl), 2
             else:
-                if row["low"] <= current_tp: is_closed, exit_price, exit_reason = True, float(current_tp), 1
-                elif row["close"] >= current_sl: is_closed, exit_price, exit_reason = True, float(current_sl), 2
+                if row["low"] <= current_tp:
+                    is_closed, exit_price_raw, exit_reason = True, float(current_tp), 1
+                elif row["close"] >= current_sl:
+                    is_closed, exit_price_raw, exit_reason = True, float(current_sl), 2
 
             if not is_closed and _force_close_time(ts):
-                is_closed, exit_price, exit_reason = True, _quant(float(row["close"])), 3
+                is_closed, exit_price_raw, exit_reason = True, _quant(float(row["close"])), 3
 
             if is_closed:
+                exit_price = _quant(exit_price_raw)
+                if EXACT_MATCH_MODE:
+                    exit_side = 'sell' if direction == 1 else 'buy'
+                    exit_price = _quant(apply_slippage(exit_price, exit_side, SLIPPAGE_MODE, SLIPPAGE_VALUE))
                 pnl_gross = (exit_price - entry_price) * position_size if direction == 1 else (entry_price - exit_price) * position_size
                 pnl_net = pnl_gross - (commission_per_side * 2.0)
                 cash += pnl_gross
@@ -144,16 +168,15 @@ def run_fast_backtest_exact(
                     trade_count += 1
 
                 trades_today += 1
-                if stop_after_first_win and pnl_net > 0: stop_trading_for_day = True
-                # --- INICIO DE LA MODIFICACIÓN ---
-                # La lógica sigue siendo la misma, pero el valor de 'first_trade_loss_stop' ahora es dinámico.
-                elif trades_today == 1 and pnl_net <= first_trade_loss_stop: stop_trading_for_day = True
-                # --- FIN DE LA MODIFICACIÓN ---
-                elif trades_today >= max_trades_per_day: stop_trading_for_day = True
+                if stop_after_first_win and pnl_net > 0:
+                    stop_trading_for_day = True
+                elif trades_today == 1 and pnl_net <= first_trade_loss_stop:
+                    stop_trading_for_day = True
+                elif trades_today >= max_trades_per_day:
+                    stop_trading_for_day = True
 
                 direction, position_size = 0, 0.0
-                
-                # Ahora se llama al reseteo parcial, que no borra la memoria del día.
+
                 strat.reset()
 
         unrealized = 0.0
@@ -175,18 +198,28 @@ def run_fast_backtest_exact(
             if isinstance(signal, dict):
                 sig_type = str(signal.get("type", "HOLD")).upper()
                 if sig_type in ("BUY", "SELL"):
-                    entry_price = _quant(float(row["close"]))
+                    raw_entry_price = _quant(float(row["close"]))
                     direction = 1 if sig_type == "BUY" else -1
                     sl_price = _quant(float(signal.get("sl_price", np.nan)))
                     tp_price = _quant(float(signal.get("tp1_price", np.nan)))
 
-                    if not (np.isfinite(sl_price) and np.isfinite(tp_price) and entry_price > 0):
+                    if not (np.isfinite(sl_price) and np.isfinite(tp_price) and raw_entry_price > 0):
                         direction = 0
                     else:
-                        if market.lower() == "crypto":
-                            size = (equity * float(leverage)) / entry_price
-                        else:
-                            size = np.floor((equity * float(leverage)) / entry_price)
+                        entry_price = raw_entry_price
+                        if EXACT_MATCH_MODE:
+                            entry_side = 'buy' if direction == 1 else 'sell'
+                            entry_price = _quant(apply_slippage(entry_price, entry_side, SLIPPAGE_MODE, SLIPPAGE_VALUE))
+
+                        size = compute_position_size(
+                            market=market,
+                            equity=equity,
+                            leverage=float(leverage),
+                            entry_price=entry_price,
+                            lot_step=None,
+                            min_qty=None,
+                            allow_fractional_crypto=ALLOW_FRACTIONAL_SIZE_CRYPTO,
+                        )
                         if size <= 0:
                             direction = 0
                         else:

--- a/tests/test_crypto_fractional_size.py
+++ b/tests/test_crypto_fractional_size.py
@@ -1,0 +1,103 @@
+import sys
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import agent_core.execution as execution_mod
+import strategies.vectorized_obr_exact as fast_mod
+from agent_core.execution import ExecutionSimulator
+from strategies.vectorized_obr_exact import run_fast_backtest_exact
+
+
+class StubStrategy:
+    def __init__(self, signal_ts: pd.Timestamp, payload: dict):
+        self._signal_ts = signal_ts
+        self._payload = payload
+
+    def reset_for_new_day(self) -> None:
+        pass
+
+    def reset(self) -> None:
+        pass
+
+    def get_signal(self, data: pd.DataFrame, current_day_levels=None, daily_candle_index: int = -1):
+        return self._payload if data.index[-1] == self._signal_ts else "HOLD"
+
+
+def _base_df() -> pd.DataFrame:
+    idx = pd.date_range("2024-01-04 09:30", periods=4, freq="min", tz="America/New_York")
+    frame = pd.DataFrame(
+        {
+            "open": np.full(4, 200.0),
+            "high": np.full(4, 201.0),
+            "low": np.full(4, 199.0),
+            "close": np.full(4, 200.0),
+        },
+        index=idx,
+    )
+    frame.loc[idx[1], ["open", "high", "low", "close"]] = [200.0, 210.0, 199.0, 210.0]
+    return frame
+
+
+def _sync_flags(monkeypatch: pytest.MonkeyPatch, allow_fractional: bool) -> None:
+    for module in (execution_mod, fast_mod):
+        monkeypatch.setattr(module, "EXACT_MATCH_MODE", True, raising=False)
+        monkeypatch.setattr(module, "SLIPPAGE_MODE", "none", raising=False)
+        monkeypatch.setattr(module, "SLIPPAGE_VALUE", 0.0, raising=False)
+        monkeypatch.setattr(module, "ALLOW_FRACTIONAL_SIZE_CRYPTO", allow_fractional, raising=False)
+        monkeypatch.setattr(module, "TRADING_WINDOW_START", "09:30", raising=False)
+        monkeypatch.setattr(module, "TRADING_WINDOW_END", "11:30", raising=False)
+        monkeypatch.setattr(module, "FORCE_CLOSE_TIME", "13:00", raising=False)
+
+
+def _run_case(monkeypatch: pytest.MonkeyPatch, allow_fractional: bool):
+    _sync_flags(monkeypatch, allow_fractional)
+    df = _base_df()
+    signal_ts = df.index[0]
+    payload = {"type": "BUY", "sl_price": 190.0, "tp1_price": 210.0}
+
+    monkeypatch.setattr(
+        fast_mod,
+        "OpeningBreakRetestStrategy",
+        lambda *args, **kwargs: StubStrategy(signal_ts, payload),
+        raising=False,
+    )
+
+    executor = ExecutionSimulator(initial_capital=100.0, commission_per_trade=0.0, leverage=1)
+    executor.configure_market(market="crypto", allow_fractional_crypto=allow_fractional)
+    executor.set_strategy_reset_hook(lambda: None)
+    for ts, row in df.iterrows():
+        signal = payload if ts == signal_ts else "HOLD"
+        executor.process_signal(signal, row)
+
+    step_trades = executor.get_closed_trades()
+    fast_trades, _ = run_fast_backtest_exact(
+        df_day_with_context=df,
+        day_start_index=0,
+        day_levels={},
+        initial_capital=100.0,
+        commission_per_side=0.0,
+        leverage=1.0,
+        market="crypto",
+        max_trades_per_day=1,
+    )
+    return step_trades, fast_trades
+
+
+def test_crypto_fractional_size(monkeypatch: pytest.MonkeyPatch) -> None:
+    step_trades, fast_trades = _run_case(monkeypatch, allow_fractional=True)
+    assert len(step_trades) == 1
+    assert fast_trades.shape[0] == 1
+    step_size = step_trades[0]["size"]
+    fast_size = fast_trades[0][3]
+    assert step_size == pytest.approx(fast_size, rel=0, abs=1e-9)
+    assert step_size > 0
+    assert step_size != pytest.approx(round(step_size), rel=0, abs=1e-12)
+
+    step_trades_off, fast_trades_off = _run_case(monkeypatch, allow_fractional=False)
+    assert len(step_trades_off) == 0
+    assert fast_trades_off.shape[0] == 0

--- a/tests/test_equivalence_fast_vs_visual.py
+++ b/tests/test_equivalence_fast_vs_visual.py
@@ -1,0 +1,131 @@
+import sys
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import agent_core.execution as execution_mod
+import strategies.vectorized_obr_exact as fast_mod
+from agent_core.execution import ExecutionSimulator
+from strategies.vectorized_obr_exact import run_fast_backtest_exact
+
+
+class StubStrategy:
+    def __init__(self, signals: dict[pd.Timestamp, dict]):
+        self._signals = signals
+
+    def reset_for_new_day(self) -> None:
+        pass
+
+    def reset(self) -> None:
+        pass
+
+    def get_signal(self, data: pd.DataFrame, current_day_levels: dict | None = None, daily_candle_index: int = -1):
+        ts = data.index[-1]
+        return self._signals.get(ts, "HOLD")
+
+
+def _build_day_dataframe() -> pd.DataFrame:
+    idx = pd.date_range(
+        "2024-01-02 09:30", "2024-01-02 13:00", freq="min", tz="America/New_York"
+    )
+    base = pd.DataFrame(
+        {
+            "open": np.full(len(idx), 100.0),
+            "high": np.full(len(idx), 100.5),
+            "low": np.full(len(idx), 99.5),
+            "close": np.full(len(idx), 100.0),
+        },
+        index=idx,
+    )
+    base.loc[idx[0], ["open", "high", "low", "close"]] = [100.0, 101.0, 99.0, 100.0]
+    base.loc[idx[1], ["open", "high", "low", "close"]] = [100.2, 102.4, 100.1, 102.0]
+    base.loc[idx[30], ["open", "high", "low", "close"]] = [98.0, 99.0, 97.5, 98.0]
+    base.loc[idx[31], ["open", "high", "low", "close"]] = [97.8, 98.5, 95.5, 96.0]
+    return base
+
+
+def _prepare_signals(idx: pd.DatetimeIndex) -> dict[pd.Timestamp, dict]:
+    return {
+        idx[0]: {"type": "BUY", "sl_price": 99.0, "tp1_price": 102.0},
+        idx[30]: {"type": "SELL", "sl_price": 99.5, "tp1_price": 96.0},
+    }
+
+
+def _sync_module_flags(monkeypatch: pytest.MonkeyPatch) -> None:
+    for module in (execution_mod, fast_mod):
+        monkeypatch.setattr(module, "EXACT_MATCH_MODE", True, raising=False)
+        monkeypatch.setattr(module, "SLIPPAGE_MODE", "none", raising=False)
+        monkeypatch.setattr(module, "SLIPPAGE_VALUE", 0.0, raising=False)
+        monkeypatch.setattr(module, "TRADING_WINDOW_START", "09:30", raising=False)
+        monkeypatch.setattr(module, "TRADING_WINDOW_END", "11:30", raising=False)
+        monkeypatch.setattr(module, "FORCE_CLOSE_TIME", "13:00", raising=False)
+
+
+def test_equivalence_fast_vs_visual(monkeypatch: pytest.MonkeyPatch) -> None:
+    _sync_module_flags(monkeypatch)
+
+    df = _build_day_dataframe()
+    signals = _prepare_signals(df.index)
+
+    monkeypatch.setattr(
+        fast_mod,
+        "OpeningBreakRetestStrategy",
+        lambda *args, **kwargs: StubStrategy(signals),
+        raising=False,
+    )
+
+    executor = ExecutionSimulator(initial_capital=1000.0, commission_per_trade=0.85, leverage=5)
+    executor.configure_market(market="stocks")
+    executor.set_strategy_reset_hook(lambda: None)
+
+    for ts, row in df.iterrows():
+        payload = signals.get(ts, "HOLD")
+        executor.process_signal(payload, row)
+
+    step_trades = executor.get_closed_trades()
+    fast_trades, _ = run_fast_backtest_exact(
+        df_day_with_context=df,
+        day_start_index=0,
+        day_levels={},
+        initial_capital=1000.0,
+        commission_per_side=0.85,
+        leverage=5.0,
+        market="stocks",
+        stop_after_first_win=False,
+        max_trades_per_day=5,
+    )
+
+    assert len(step_trades) == fast_trades.shape[0] == 2
+
+    fast_records = []
+    for row in fast_trades:
+        entry_ts = pd.to_datetime(row[0], unit="s", utc=True).tz_convert("America/New_York")
+        exit_ts = pd.to_datetime(row[1], unit="s", utc=True).tz_convert("America/New_York")
+        fast_records.append(
+            {
+                "entry_time": entry_ts,
+                "exit_time": exit_ts,
+                "direction": "LONG" if int(row[2]) == 1 else "SHORT",
+                "size": float(row[3]),
+                "entry_price": float(row[4]),
+                "exit_price": float(row[5]),
+                "pnl": float(row[6]),
+            }
+        )
+
+    for step_trade, fast_trade in zip(step_trades, fast_records):
+        assert step_trade["entry_time"] == fast_trade["entry_time"]
+        assert step_trade["exit_time"] == fast_trade["exit_time"]
+        assert step_trade["direction"] == fast_trade["direction"]
+        assert step_trade["size"] == pytest.approx(fast_trade["size"], rel=0, abs=1e-9)
+        assert step_trade["entry_price"] == pytest.approx(fast_trade["entry_price"], rel=0, abs=1e-9)
+        assert step_trade["exit_price"] == pytest.approx(fast_trade["exit_price"], rel=0, abs=1e-9)
+        assert step_trade["pnl_net"] == pytest.approx(fast_trade["pnl"], rel=0, abs=1e-9)
+
+    total_step = sum(trade["pnl_net"] for trade in step_trades)
+    total_fast = sum(record["pnl"] for record in fast_records)
+    assert total_step == pytest.approx(total_fast, rel=0, abs=1e-9)

--- a/tests/test_force_close_and_reset.py
+++ b/tests/test_force_close_and_reset.py
@@ -1,0 +1,107 @@
+import sys
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import agent_core.execution as execution_mod
+import strategies.vectorized_obr_exact as fast_mod
+from agent_core.execution import ExecutionSimulator, TradeState
+from strategies.vectorized_obr_exact import run_fast_backtest_exact
+
+
+class StubStrategy:
+    def __init__(self, signal_ts: pd.Timestamp, payload: dict):
+        self._signal_ts = signal_ts
+        self._payload = payload
+
+    def reset_for_new_day(self) -> None:
+        pass
+
+    def reset(self) -> None:
+        pass
+
+    def get_signal(self, data: pd.DataFrame, current_day_levels=None, daily_candle_index: int = -1):
+        return self._payload if data.index[-1] == self._signal_ts else "HOLD"
+
+
+class ResetRecorder:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def __call__(self) -> None:
+        self.calls += 1
+
+
+def _build_df() -> pd.DataFrame:
+    idx = pd.date_range("2024-01-05 09:30", "2024-01-05 13:05", freq="min", tz="America/New_York")
+    frame = pd.DataFrame(
+        {
+            "open": np.full(len(idx), 100.0),
+            "high": np.full(len(idx), 100.2),
+            "low": np.full(len(idx), 99.8),
+            "close": np.full(len(idx), 100.0),
+        },
+        index=idx,
+    )
+    return frame
+
+
+def _sync_flags(monkeypatch: pytest.MonkeyPatch) -> None:
+    for module in (execution_mod, fast_mod):
+        monkeypatch.setattr(module, "EXACT_MATCH_MODE", True, raising=False)
+        monkeypatch.setattr(module, "SLIPPAGE_MODE", "none", raising=False)
+        monkeypatch.setattr(module, "SLIPPAGE_VALUE", 0.0, raising=False)
+        monkeypatch.setattr(module, "TRADING_WINDOW_START", "09:30", raising=False)
+        monkeypatch.setattr(module, "TRADING_WINDOW_END", "11:30", raising=False)
+        monkeypatch.setattr(module, "FORCE_CLOSE_TIME", "13:00", raising=False)
+
+
+def test_force_close_and_reset(monkeypatch: pytest.MonkeyPatch) -> None:
+    _sync_flags(monkeypatch)
+    df = _build_df()
+    signal_ts = pd.Timestamp("2024-01-05 10:30", tz="America/New_York")
+    payload = {"type": "BUY", "sl_price": 95.0, "tp1_price": 120.0}
+
+    monkeypatch.setattr(
+        fast_mod,
+        "OpeningBreakRetestStrategy",
+        lambda *args, **kwargs: StubStrategy(signal_ts, payload),
+        raising=False,
+    )
+
+    recorder = ResetRecorder()
+    executor = ExecutionSimulator(initial_capital=1000.0, commission_per_trade=0.0, leverage=1)
+    executor.configure_market(market="stocks")
+    executor.set_strategy_reset_hook(recorder)
+
+    for ts, row in df.iterrows():
+        signal = payload if ts == signal_ts else "HOLD"
+        executor.process_signal(signal, row)
+
+    step_trades = executor.get_closed_trades()
+    assert len(step_trades) == 1
+    step_trade = step_trades[0]
+    assert step_trade["exit_reason"] == "ForceClose"
+    assert step_trade["exit_time"] == pd.Timestamp("2024-01-05 13:00", tz="America/New_York")
+    assert executor.account_fsm.is_in_state(TradeState.FLAT)
+    assert recorder.calls == 1
+
+    fast_trades, _ = run_fast_backtest_exact(
+        df_day_with_context=df,
+        day_start_index=0,
+        day_levels={},
+        initial_capital=1000.0,
+        commission_per_side=0.0,
+        leverage=1.0,
+        market="stocks",
+        max_trades_per_day=1,
+    )
+    assert fast_trades.shape[0] == 1
+    fast_trade = fast_trades[0]
+    exit_ts = pd.to_datetime(fast_trade[1], unit="s", utc=True).tz_convert("America/New_York")
+    assert exit_ts == pd.Timestamp("2024-01-05 13:00", tz="America/New_York")
+    assert int(fast_trade[7]) == 3

--- a/tests/test_slippage_modes.py
+++ b/tests/test_slippage_modes.py
@@ -1,0 +1,104 @@
+import sys
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import agent_core.execution as execution_mod
+import strategies.vectorized_obr_exact as fast_mod
+from agent_core.execution import ExecutionSimulator
+from shared.slippage import apply_slippage
+from strategies.vectorized_obr_exact import run_fast_backtest_exact
+
+
+class StubStrategy:
+    def __init__(self, signal_ts: pd.Timestamp, payload: dict):
+        self._timestamp = signal_ts
+        self._payload = payload
+
+    def reset_for_new_day(self) -> None:
+        pass
+
+    def reset(self) -> None:
+        pass
+
+    def get_signal(self, data: pd.DataFrame, current_day_levels=None, daily_candle_index: int = -1):
+        ts = data.index[-1]
+        if ts == self._timestamp:
+            return self._payload
+        return "HOLD"
+
+
+def _sync_flags(monkeypatch: pytest.MonkeyPatch, mode: str, value: float) -> None:
+    for module in (execution_mod, fast_mod):
+        monkeypatch.setattr(module, "EXACT_MATCH_MODE", True, raising=False)
+        monkeypatch.setattr(module, "SLIPPAGE_MODE", mode, raising=False)
+        monkeypatch.setattr(module, "SLIPPAGE_VALUE", value, raising=False)
+        monkeypatch.setattr(module, "TRADING_WINDOW_START", "09:30", raising=False)
+        monkeypatch.setattr(module, "TRADING_WINDOW_END", "11:30", raising=False)
+        monkeypatch.setattr(module, "FORCE_CLOSE_TIME", "13:00", raising=False)
+
+
+def _build_df() -> pd.DataFrame:
+    idx = pd.date_range("2024-01-03 09:30", periods=5, freq="min", tz="America/New_York")
+    base = pd.DataFrame(
+        {
+            "open": np.full(5, 100.0),
+            "high": np.full(5, 100.5),
+            "low": np.full(5, 99.5),
+            "close": np.full(5, 100.0),
+        },
+        index=idx,
+    )
+    base.loc[idx[0], ["open", "high", "low", "close"]] = [100.0, 100.5, 99.5, 100.0]
+    base.loc[idx[1], ["open", "high", "low", "close"]] = [100.0, 102.0, 100.0, 102.0]
+    return base
+
+
+@pytest.mark.parametrize("mode,value", [("none", 0.0), ("points", 0.5), ("percent", 0.01)])
+def test_slippage_modes(monkeypatch: pytest.MonkeyPatch, mode: str, value: float) -> None:
+    _sync_flags(monkeypatch, mode, value)
+
+    df = _build_df()
+    signal_ts = df.index[0]
+    payload = {"type": "BUY", "sl_price": 99.0, "tp1_price": 102.0}
+    monkeypatch.setattr(
+        fast_mod,
+        "OpeningBreakRetestStrategy",
+        lambda *args, **kwargs: StubStrategy(signal_ts, payload),
+        raising=False,
+    )
+
+    executor = ExecutionSimulator(initial_capital=1000.0, commission_per_trade=0.0, leverage=1)
+    executor.configure_market(market="stocks")
+    executor.set_strategy_reset_hook(lambda: None)
+
+    for ts, row in df.iterrows():
+        signal = payload if ts == signal_ts else "HOLD"
+        executor.process_signal(signal, row)
+
+    step_trade = executor.get_closed_trades()[0]
+    fast_trades, _ = run_fast_backtest_exact(
+        df_day_with_context=df,
+        day_start_index=0,
+        day_levels={},
+        initial_capital=1000.0,
+        commission_per_side=0.0,
+        leverage=1.0,
+        market="stocks",
+        max_trades_per_day=1,
+    )
+    fast_trade = fast_trades[0]
+
+    raw_entry = 100.0
+    raw_exit = 102.0
+    expected_entry = apply_slippage(raw_entry, "buy", mode, value)
+    expected_exit = apply_slippage(raw_exit, "sell", mode, value)
+
+    assert step_trade["entry_price"] == pytest.approx(expected_entry, rel=0, abs=1e-9)
+    assert step_trade["exit_price"] == pytest.approx(expected_exit, rel=0, abs=1e-9)
+    assert fast_trade[4] == pytest.approx(expected_entry, rel=0, abs=1e-9)
+    assert fast_trade[5] == pytest.approx(expected_exit, rel=0, abs=1e-9)


### PR DESCRIPTION
## Summary
- add shared configuration, time window, slippage, and sizing utilities to drive EXACT_MATCH_MODE behaviour
- update ExecutionSimulator to honor the shared flags (time windows, forced close, unified slippage, fractional crypto sizing) and expose reset hooks
- mirror the same slippage and sizing logic in the fast vectorized engine and add regression tests for equivalence, slippage, crypto sizing, and force-close reset

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68d056c5e5a48324b2f5d72aa499ea71