### PR TITLE
Fix: Guardar ORH/ORL hasta fin de OR en motor paso a paso

### DIFF
--- a/agent_core/execution.py
+++ b/agent_core/execution.py
@@ -146,6 +146,8 @@ class ExecutionSimulator:
 
         logger.info(f"ExecutionSimulator (FSM) inicializado: Capital={self.initial_capital:.2f}, Leverage={self.leverage}:1")
 
+        self._activate_or_guard_if_available()
+
     def set_leverage(self, new_leverage: int):
         """Permite actualizar el apalancamiento dinámicamente."""
         old_leverage = self.leverage
@@ -188,6 +190,24 @@ class ExecutionSimulator:
         if strategy and hasattr(strategy, 'reset'):
             self._strategy_reset_hook = lambda s=strategy: s.reset()
         return self._strategy_reset_hook
+
+    def _activate_or_guard_if_available(self) -> None:
+        strategy = getattr(self, 'obr_strategy', None)
+        if strategy is None:
+            main_module = sys.modules.get('agent_core.main')
+            strategy = getattr(main_module, 'obr_strategy', None) if main_module else None
+            if strategy is not None:
+                self.obr_strategy = strategy
+
+        if not strategy:
+            return
+
+        try:
+            strategy.or_guard_enabled = True
+            strategy.or_exec_minutes = 10
+            strategy.or_tz = 'America/New_York'
+        except Exception as exc:  # pragma: no cover - defensive guard
+            logger.debug("No se pudo activar el guard de OR para la estrategia: %s", exc)
 
     def _on_trade_closed(self) -> None:
         if not EXACT_MATCH_MODE:

--- a/strategies/opening_br_strategy.py
+++ b/strategies/opening_br_strategy.py
@@ -19,20 +19,28 @@ class OpeningBreakRetestStrategy(BaseStrategy):
         self.ema_periods = self.params.get('ema_periods', [9, 21, 50])
         self.ema_filter_mode = self.params.get('ema_filter_mode', 'Desactivado').capitalize()
         self.use_ema_filter = self.ema_filter_mode != 'Desactivado'
-        
+
         self.sl_method = self.params.get('sl_method', 'LOOKBACK_MIN_MAX').upper()
         self.sl_default_lookback_candles = max(1, int(self.params.get('sl_lookback', 2)) + 1)
         self.sl_reduced_lookback_candles = 2
         self.risk_reward_ratio = self.params.get('risk_reward_ratio', 2.0)
 
+        self.or_guard_enabled = bool(self.params.get('or_guard_enabled', False))
+        self.or_exec_minutes = int(self.params.get('or_exec_minutes', 10))
+        self.or_tz = self.params.get('or_tz', 'America/New_York')
+        self._or_ready_ts: pd.Timestamp | None = None
+        self._or_ready_day: pd.Timestamp | None = None
+
         self.level_fsms = {}
         self.last_levels_processed = None
-        
+
         logger.debug("Estrategia OBR (FSM) inicializada (versión con EMAs pre-calculadas).")
 
     def reset_for_new_day(self):
         self.level_fsms = {}
         self.last_levels_processed = None
+        self._or_ready_ts = None
+        self._or_ready_day = None
         logger.debug("Estrategia OBR (FSM) reseteada para un nuevo día.")
 
     def reset(self):
@@ -45,7 +53,9 @@ class OpeningBreakRetestStrategy(BaseStrategy):
 
         logger.info(f"Inicializando FSMs para nuevos niveles: {current_day_levels}")
         self.level_fsms = {}
-        
+        self._or_ready_ts = None
+        self._or_ready_day = None
+
         orh, orl = current_day_levels.get('ORH'), current_day_levels.get('ORL')
         high_levels, low_levels = ['ORH', 'PMH', 'PDH'], ['ORL', 'PML', 'PDL']
 
@@ -68,8 +78,10 @@ class OpeningBreakRetestStrategy(BaseStrategy):
 
         current_candle, previous_candle = data.iloc[-1], data.iloc[-2]
         current_candle_idx = daily_candle_index if daily_candle_index != -1 else len(data) - 1
-        
+
         for level_name, fsm in self.level_fsms.items():
+            if self._should_guard_or_level(level_name, current_candle.name):
+                continue
             if fsm.state not in [State.SIGNAL_EMITTED, State.INVALIDATED]:
                 signal_info = fsm.process_candle(current_candle, previous_candle, current_candle_idx)
                 if signal_info:
@@ -184,4 +196,63 @@ class OpeningBreakRetestStrategy(BaseStrategy):
             if self.ema_filter_mode == 'Fuerte': return strong
             if self.ema_filter_mode == 'Moderado': return moderate
         return False
+
+    def _should_guard_or_level(self, level_name: str, candle_ts) -> bool:
+        if not self.or_guard_enabled or level_name not in ('ORH', 'ORL'):
+            return False
+        if candle_ts is None:
+            return False
+
+        ready_ts = self._ensure_or_guard_ready_ts(candle_ts)
+        if ready_ts is None:
+            return False
+
+        try:
+            ts = pd.Timestamp(candle_ts)
+            if ready_ts.tzinfo is not None:
+                if ts.tzinfo is None:
+                    ts = ts.tz_localize(ready_ts.tz)
+                else:
+                    ts = ts.tz_convert(ready_ts.tz)
+        except Exception:
+            return False
+
+        if ts < ready_ts:
+            logger.debug(f"Guard OR activo: se omite {level_name} en {ts} (< {ready_ts})")
+            return True
+        return False
+
+    def _ensure_or_guard_ready_ts(self, candle_ts) -> pd.Timestamp | None:
+        if not self.or_guard_enabled or candle_ts is None:
+            return None
+
+        try:
+            ts = pd.Timestamp(candle_ts)
+        except Exception:
+            return None
+
+        tz_name = getattr(self, 'or_tz', 'America/New_York') or 'America/New_York'
+
+        try:
+            if ts.tzinfo is None:
+                ts = ts.tz_localize(tz_name)
+            else:
+                ts = ts.tz_convert(tz_name)
+        except Exception:
+            return None
+
+        day_anchor = ts.normalize()
+        if self._or_ready_day is not None and day_anchor == self._or_ready_day:
+            return self._or_ready_ts
+
+        try:
+            exec_minutes = int(self.or_exec_minutes)
+        except Exception:
+            exec_minutes = 10
+        exec_minutes = max(0, exec_minutes)
+
+        or_start = day_anchor + pd.Timedelta(hours=9, minutes=30)
+        self._or_ready_ts = or_start + pd.Timedelta(minutes=exec_minutes)
+        self._or_ready_day = day_anchor
+        return self._or_ready_ts
 

--- a/tests/test_or_guard_step_by_step.py
+++ b/tests/test_or_guard_step_by_step.py
@@ -1,0 +1,65 @@
+import pytest
+
+pd = pytest.importorskip("pandas")
+
+from strategies.opening_br_strategy import OpeningBreakRetestStrategy
+from strategies.level_fsm import State
+
+
+def _build_guard_dataset() -> pd.DataFrame:
+    idx = pd.date_range(
+        "2024-01-02 09:30",
+        periods=16,
+        freq="min",
+        tz="America/New_York",
+    )
+    df = pd.DataFrame(
+        {
+            "open": 100.0,
+            "high": 100.4,
+            "low": 99.6,
+            "close": 100.0,
+        },
+        index=idx,
+    )
+
+    # Candle that breaks ORH after the guard window (09:41)
+    df.loc[idx[11], ["open", "high", "low", "close"]] = [100.4, 101.6, 99.9, 101.1]
+    # Stabilise above ORH waiting for retest
+    df.loc[idx[12], ["open", "high", "low", "close"]] = [101.0, 101.4, 100.8, 101.2]
+    # Retest within the tolerance zone and close back above ORH (09:43)
+    df.loc[idx[13], ["open", "high", "low", "close"]] = [101.1, 101.3, 100.6, 101.05]
+
+    return df
+
+
+def test_or_levels_guard_delays_processing_until_or_end():
+    df = _build_guard_dataset()
+    levels = {"ORH": 100.5, "ORL": 99.5}
+
+    strat = OpeningBreakRetestStrategy(
+        or_guard_enabled=True,
+        or_exec_minutes=10,
+        or_tz="America/New_York",
+    )
+    strat.reset_for_new_day()
+
+    last_signal = "HOLD"
+    for i, ts in enumerate(df.index):
+        window = df.iloc[: i + 1]
+        signal = strat.get_signal(window, current_day_levels=levels, daily_candle_index=i)
+        if window.shape[0] < 2:
+            continue
+
+        if ts < pd.Timestamp("2024-01-02 09:40", tz="America/New_York"):
+            assert strat.level_fsms["ORH"].state == State.IDLE
+        elif ts == pd.Timestamp("2024-01-02 09:41", tz="America/New_York"):
+            assert strat.level_fsms["ORH"].state == State.BROKEN
+        elif ts == pd.Timestamp("2024-01-02 09:43", tz="America/New_York"):
+            assert isinstance(signal, dict)
+            assert signal["type"].upper() == "BUY"
+            assert strat.level_fsms["ORH"].state == State.SIGNAL_EMITTED
+        last_signal = signal
+
+    assert isinstance(last_signal, dict)
+    assert last_signal["level"] == "ORH"


### PR DESCRIPTION
## Summary
- add optional Opening Range guard attributes to the OBR strategy so ORH/ORL levels stay frozen until the opening window finishes
- enable the guard only when running through the step-by-step execution simulator to keep the fast engine untouched
- add a regression test that exercises the guard behaviour around the 10 minute OR window

## Testing
- pytest tests/test_or_guard_step_by_step.py *(skipped: pandas not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d0657928748324811b82aa2d4cfbea